### PR TITLE
Fixed mci bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can refer [DEVELOPMENT.md](DEVELOPMENT.md).
 </dependency>
 ```
 
-You can also download the project, build it with `mvn clean install` and add the generated jar to your buildpath.
+You can also download the project, build it with `mvn package` and add the generated jar to your buildpath.
 
 ##### Via Gradle:
 ```gradle

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Well, with `clean` you delete the project cache of Maven which makes the build much slower. With `install`, the artifact will be copied to the `~/.m2` directory, which you don't want in this case. You want just to build the artifact, so `mvn package` is the correct command…

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coding/emoji-java/1)
<!-- Reviewable:end -->
