### PR TITLE
Fixed mci bug part ii

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,7 +3,7 @@ This repository is derived from [vdurmont/emoji-java](https://github.com/vdurmon
 Coding makes some change in this version to be used in product more suitable.
 
 ## How to build it?
-The project uses maven as build tool. You can use `mvn clean install` to build jar.
+The project uses maven as build tool. You can use `mvn package` to build jar.
 After that, you can copy the jar under `target/` into your project libs.
 
 ## How to use it?


### PR DESCRIPTION
Well, with `clean` you delete the project cache of Maven which makes the build much slower. With `install`, the artifact will be copied to the `~/.m2` directory, which you don't want in this case. You want just to build the artifact, so `mvn package` is the correct command…

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coding/emoji-java/2)
<!-- Reviewable:end -->
